### PR TITLE
Only render responsive views when enabled

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -59,14 +59,11 @@ export class Decorator extends Component {
     return <div style={{ margin: 15 }}>{this.story}</div>
   }
 
-  renderViews = () => {
-    return (
-      <>
-        {this.renderStory()}
-        <ResponsiveView breakpoints={this.props.breakpoints}>{this.story.props.children}</ResponsiveView>
-      </>
-    )
-  }
+  renderViews = () => (
+    <ResponsiveView breakpoints={this.props.breakpoints}>
+      {this.story.props.children}
+    </ResponsiveView>
+  );
 
   render() {
     const { enableViews } = this.state


### PR DESCRIPTION
We have a number of stories which are positioned absolutely, such as modals and sticky navs. These don't work well with the addon currently, because they render the contents of the story on top of the responsive views.

But I don't think we ever need to see the original story when we have the addon enabled; if we need to see the original story, we can always click to switch off the addon. I propose dropping the "raw" story from the top of the output, and only showing the responsive views while the addon is active.