### PR TITLE
Make addon work in storybook 6.4.18

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "files": [
-    "dist",
+    "src",
     "register.js"
   ],
   "repository": {

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "access": "public"
   },
   "files": [
-    "src",
+    "dist",
     "register.js"
   ],
   "repository": {
@@ -25,7 +25,7 @@
     "url": "https://github.com/vizeat/storybook-addon-responsive-views.git"
   },
   "license": "MIT",
-  "main": "src/index.js",
+  "main": "dist/index.js",
   "dependencies": {
     "@storybook/addons": "^5.0.0",
     "@storybook/components": "^5.1.11",
@@ -62,6 +62,7 @@
   "scripts": {
     "build": "BABEL_ENV=production babel src/ --out-dir dist/ --copy-files",
     "pub": "yarn build && yarn publish && git push --follow-tags",
-    "lint": "eslint --cache -c .eslintrc src --ext .js,.jsx"
+    "lint": "eslint --cache -c .eslintrc src --ext .js,.jsx",
+    "postinstall": "npm run build"
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "url": "https://github.com/vizeat/storybook-addon-responsive-views.git"
   },
   "license": "MIT",
-  "main": "dist/index.js",
+  "main": "src/index.js",
   "dependencies": {
     "@storybook/addons": "^5.0.0",
     "@storybook/components": "^5.1.11",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "build": "BABEL_ENV=production babel src/ --out-dir dist/ --copy-files",
     "pub": "yarn build && yarn publish && git push --follow-tags",
     "lint": "eslint --cache -c .eslintrc src --ext .js,.jsx",
-    "postinstall": "npm run build"
+    "prepare": "npm run build"
   }
 }

--- a/src/ResponsiveView.js
+++ b/src/ResponsiveView.js
@@ -6,20 +6,7 @@ import Frame, { FrameContextConsumer } from 'react-frame-component'
 export function ResponsiveView(props) {
   if (!props.renderViews) return null
 
-  const VIEWPORTS = Object.keys(props.breakpoints).reduce(
-    (acc, item) => {
-      const key = item.toLowerCase().replace(/^(.)|\s(.)/g, ($1) => $1.toUpperCase())
-      const value = props.breakpoints[item]
-
-      const belowBreakpoint = {
-        name: `${key}: ${value - 1}px (limit before breakpoint)`,
-        width: `${value - 1}px`,
-      }
-      const breakpoint = { name: `${key}: ${value}px`, width: `${value}px` }
-      return [...acc, belowBreakpoint, breakpoint]
-    },
-    [{ name: `Minimum: 320px`, width: '320px' }],
-  )
+  const VIEWPORTS = Object.keys(props.breakpoints)
 
   /**
    * All storybook stories are rendered inside an iFrame that contains the styles

--- a/src/ResponsiveView.js
+++ b/src/ResponsiveView.js
@@ -27,7 +27,7 @@ export function ResponsiveView(props) {
       {VIEWPORTS.map(({ name, width }, i) => (
         <div key={i} style={{ margin: 15 }}>
           <p style={{ fontFamily: 'sans-serif' }}>{name}</p>
-          <div style={{ height: 300, width }}>
+          <div style={{ height: 568, width }}>
             {/*
              * Every viewport content must be rendered inside an iFrame to ensure
              * that all the component's media queries are really activated when its

--- a/src/ResponsiveView.js
+++ b/src/ResponsiveView.js
@@ -6,7 +6,12 @@ import Frame, { FrameContextConsumer } from 'react-frame-component'
 export function ResponsiveView(props) {
   if (!props.renderViews) return null
 
-  const VIEWPORTS = Object.keys(props.breakpoints)
+  const VIEWPORTS = Object.keys(props.breakpoints).reduce((acc, key) => {
+    const value = props.breakpoints[key];
+
+    const breakpoint = { name: `${key}: ${value}px`, width: `${value}px` };
+    return [...acc, breakpoint];
+  }, []);
 
   /**
    * All storybook stories are rendered inside an iFrame that contains the styles

--- a/src/index.js
+++ b/src/index.js
@@ -62,7 +62,6 @@ export class Decorator extends Component {
   renderViews = () => {
     return (
       <>
-        {this.renderStory()}
         <ResponsiveView breakpoints={this.props.breakpoints}>{this.story}</ResponsiveView>
       </>
     )

--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ export class Decorator extends Component {
     return (
       <>
         {this.renderStory()}
-        <ResponsiveView breakpoints={this.props.breakpoints}>{this.story.props.children}</ResponsiveView>
+        <ResponsiveView breakpoints={this.props.breakpoints}>{this.story}</ResponsiveView>
       </>
     )
   }


### PR DESCRIPTION
I guess somewhere along the way Storybook's API has changed and stories stopped showing up in the views. The required change is really minuscule.

Before
![Screenshot 2022-02-28 at 21 49 38](https://user-images.githubusercontent.com/13262428/156056601-476e9918-d150-444a-afee-d011f97960e9.png)

After
![Screenshot 2022-02-28 at 21 54 29](https://user-images.githubusercontent.com/13262428/156057098-873b94aa-0a95-4aac-a454-5cde4b6d84fe.png)

