### PR TITLE
Make addon work in storybook 6.4.18

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -63,7 +63,7 @@ export class Decorator extends Component {
     return (
       <>
         {this.renderStory()}
-        <ResponsiveView breakpoints={this.props.breakpoints}>{this.story.props.children}</ResponsiveView>
+        <ResponsiveView breakpoints={this.props.breakpoints}>{this.story}</ResponsiveView>
       </>
     )
   }


### PR DESCRIPTION
I guess somewhere along the way Storybook's API has changed and stories stopped showing up in the views. The required change is really minuscule.

Before
![Screenshot 2022-02-28 at 21 49 38](https://user-images.githubusercontent.com/13262428/156056601-476e9918-d150-444a-afee-d011f97960e9.png)

After
![Screenshot 2022-02-28 at 21 54 29](https://user-images.githubusercontent.com/13262428/156057098-873b94aa-0a95-4aac-a454-5cde4b6d84fe.png)

